### PR TITLE
Bug 1402675 - Added support for tls in mongo connection strings

### DIFF
--- a/lib/mongo/protocol.ex
+++ b/lib/mongo/protocol.ex
@@ -40,7 +40,7 @@ defmodule Mongo.Protocol do
       auth_mechanism: opts[:auth_mechanism] || nil,
       connection_type: Keyword.fetch!(opts, :connection_type),
       topology_pid: Keyword.fetch!(opts, :topology_pid),
-      ssl: opts[:ssl] || false,
+      ssl: opts[:ssl] || opts[:tls] || false,
       status: :idle,
       session: nil
     }

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -41,6 +41,7 @@ defmodule Mongo.UrlParser do
     "serverSelectionTryOnce" => ["true", "false"],
     "heartbeatFrequencyMS" => :number,
     "retryWrites" => ["true", "false"],
+    "tls" => ["true", "false"],
     "uuidRepresentation" => ["standard", "csharpLegacy", "javaLegacy", "pythonLegacy"],
     # Elixir Driver options
     "type" => ["unknown", "single", "replicaSetNoPrimary", "sharded"]

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -18,7 +18,7 @@ defmodule Mongo.UrlParserTest do
       assert password = "2yPK}Bzj|qE($^1JDdk4J42*&4lLgV%C"
     end
 
-    test "cluster url" do
+    test "cluster url with ssl" do
       url =
         "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?ssl=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
 
@@ -30,6 +30,26 @@ defmodule Mongo.UrlParserTest do
                auth_source: "admin",
                set_name: "set-name",
                ssl: true,
+               seeds: [
+                 "seed1.domain.com:27017",
+                 "seed2.domain.com:27017",
+                 "seed3.domain.com:27017"
+               ]
+             ]
+    end
+
+    test "cluster url with tls" do
+      url =
+        "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?tls=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
+
+      assert UrlParser.parse_url(url: url) == [
+               username: "user",
+               password: "password",
+               database: "db_name",
+               pool_size: 5,
+               auth_source: "admin",
+               set_name: "set-name",
+               tls: true,
                seeds: [
                  "seed1.domain.com:27017",
                  "seed2.domain.com:27017",


### PR DESCRIPTION
Mongo database connections could not be established when 'tls=true' was included in connection strings. With this change, the presence of 'tls=true' is the same as 'ssl=true'.